### PR TITLE
Event changes to handle cleanups

### DIFF
--- a/bot/extensions/events.py
+++ b/bot/extensions/events.py
@@ -11,6 +11,7 @@ import discord
 import pendulum
 import prettify_exceptions
 import slate.obsidian
+from async_timeout import asyncio
 from discord.ext import commands
 
 # My stuff
@@ -319,6 +320,19 @@ class Events(commands.Cog):
                         f"**Time:** {utils.format_datetime(pendulum.now(tz='UTC'), format=enums.DatetimeFormat.PARTIAL_LONG_DATETIME)}",
         )
         await self.bot._log_webhooks[enums.LogType.COMMAND].send(embed=embed, username=f"{ctx.author}", avatar_url=utils.avatar(ctx.author))
+
+    @commands.Cog.listener("on_voice_state_update")
+    async def voice_client_cleanup(self, member: discord.Member, before: discord.VoiceState, after: discord.VoiceState) -> None:
+
+        assert self.bot.user is not None
+        if member.id != self.bot.user.id:
+            return
+
+        if before.channel and not after.channel:
+            if before.channel.guild.voice_client:
+                # Clean up forced DC's
+                await before.channel.guild.voice_client.disconnect(force=True)
+                return
 
     # Slate events
 

--- a/bot/extensions/events.py
+++ b/bot/extensions/events.py
@@ -11,7 +11,6 @@ import discord
 import pendulum
 import prettify_exceptions
 import slate.obsidian
-from async_timeout import asyncio
 from discord.ext import commands
 
 # My stuff

--- a/bot/utilities/custom/player.py
+++ b/bot/utilities/custom/player.py
@@ -172,7 +172,6 @@ class Player(slate.obsidian.Player["CD", custom.Context, "Player"]):
             return
 
         self._waiting = True
-        track = None
 
         try:
             with async_timeout.timeout(180):


### PR DESCRIPTION
Currently this now handles the event where the bot is force disconnected, and no song is given to the queue for 3 minutes.